### PR TITLE
Fix NVMe device path detection

### DIFF
--- a/src/smfc.py
+++ b/src/smfc.py
@@ -14,6 +14,7 @@ import syslog
 import time
 from typing import List, Callable
 
+import pyudev
 
 # Program version string
 version_str: str = '3.5.1'
@@ -389,6 +390,8 @@ class FanController:
                 self.get_temp_func = self.get_min_temp
             elif self.temp_calc == self.CALC_MAX:
                 self.get_temp_func = self.get_max_temp
+        # Initialize connection to udev database
+        self.udev_context = pyudev.Context()
         # Build hwmon_path list.
         self.hwmon_reserved = hwmon_reserved
         self.hwmon_path = []
@@ -788,8 +791,8 @@ class HdZone(FanController):
                 # If the current one is an NVME SSD disk.
                 # NOTE: kernel provides this, no extra modules required
                 if "nvme-" in self.hd_device_names[i]:
-                    disk_name = os.path.basename(os.readlink(self.hd_device_names[i]))
-                    search_str = os.path.join('/sys/class/nvme', disk_name, disk_name + "n1", 'hwmon*/temp1_input')
+                    device = pyudev.Devices.from_device_file(self.udev_context, self.hd_device_names[i])
+                    search_str = os.path.join(device.parent.sys_path, 'hwmon*/temp1_input')
                     file_names = glob.glob(search_str)
                     if not file_names:
                         raise ValueError(self.ERROR_MSG_FILE_IO.format(search_str))


### PR DESCRIPTION
Under linux (under the persistent naming rules present in most distributions AFAIK), the NVMe device by-id symlinks point to the block device (e.g., `/dev/nvme0n1`) rather than the controller (`/dev/nvme0`) as assumed by original code.

This change fixes the NVMe device parsing, but rather than inelegantly trying to twiddle the string (where in principle the "namespace" portion might be more than the 2 characters "n1"), we query the udev database directly, and find the parent device's sysfs path.

Unfortunately, the test file `test_00_data.py` (which contained the same symlink naming bug) doesn't have a simple fix, so someone will have to patch it more deeply. Another disadvantage is, of course, that we're adding a new dependency on pyudev, which can be another point of failure.

On the other hand, pyudev might ultimately be the way forward, and a deeper refactor might clean up some of the uglier sysfs path munging. It may also make it easier to solve  AMD autodetection.